### PR TITLE
Update Go to v1.26.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.25 as builder
+FROM golang:1.26 as builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/test-network-function/cr-scale-operator
 
-go 1.25
+go 1.26.0
 
 require (
 	github.com/onsi/ginkgo/v2 v2.6.0


### PR DESCRIPTION
## Summary
- Update Go version to 1.26.0
- [Go 1.26 Release Notes](https://go.dev/doc/go1.26)

## Jira
[CNFCERT-1344](https://issues.redhat.com/browse/CNFCERT-1344)

## Test plan
- [x] go mod tidy succeeds
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Related PRs
- [certsuite#3455](https://github.com/redhat-best-practices-for-k8s/certsuite/pull/3455)
- [certsuite-operator#283](https://github.com/redhat-best-practices-for-k8s/certsuite-operator/pull/283)
- [oct#408](https://github.com/redhat-best-practices-for-k8s/oct/pull/408)
- [collector#654](https://github.com/redhat-best-practices-for-k8s/collector/pull/654)
- [certsuite-claim#162](https://github.com/redhat-best-practices-for-k8s/certsuite-claim/pull/162)
- [kpi-collection-tool#65](https://github.com/redhat-best-practices-for-k8s/kpi-collection-tool/pull/65)
- [privileged-daemonset#336](https://github.com/redhat-best-practices-for-k8s/privileged-daemonset/pull/336)
- [perfdive#48](https://github.com/redhat-best-practices-for-k8s/perfdive/pull/48)
- [cr-scale-operator#5](https://github.com/redhat-best-practices-for-k8s/cr-scale-operator/pull/5)
- [certsuite-overview#118](https://github.com/redhat-best-practices-for-k8s/certsuite-overview/pull/118)
- [certsuite-qe#1360](https://github.com/redhat-best-practices-for-k8s/certsuite-qe/pull/1360)
- [kpi-analyzer#9](https://github.com/redhat-best-practices-for-k8s/kpi-analyzer/pull/9)
- [operator-results-spreadsheet#42](https://github.com/redhat-best-practices-for-k8s/operator-results-spreadsheet/pull/42)
- [json-parser#1](https://github.com/redhat-best-practices-for-k8s/json-parser/pull/1)