### PR TITLE
Update AGENTS.md: Go version 1.25 to 1.26.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
-# CLAUDE.md
+# AGENTS.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to AI coding agents when working with code in this repository.
 
 ## Repository Overview
 
@@ -184,7 +184,7 @@ The `MemcachedReconciler`:
 
 | Dependency | Version | Purpose |
 |------------|---------|---------|
-| Go | 1.25 | Programming language |
+| Go | 1.26.0 | Programming language |
 | controller-runtime | v0.14.1 | Operator framework |
 | Kubernetes client-go | v0.26.0 | Kubernetes API client |
 | Ginkgo | v2.6.0 | BDD testing framework |
@@ -196,7 +196,7 @@ The `MemcachedReconciler`:
 ## Development Guidelines
 
 ### Go Version
-This project uses Go 1.25. Ensure your local environment matches this version.
+This project uses Go 1.26.0. Ensure your local environment matches this version.
 
 ### Kubebuilder Scaffolding
 This project was generated using Kubebuilder v3 with the Operator SDK plugins. The project layout follows standard Kubebuilder conventions.


### PR DESCRIPTION
## Summary
- Update Go version from 1.25 to 1.26.0 to match go.mod

## Related PRs

Org-wide AGENTS.md standardization:

- [certsuite#3494](https://github.com/redhat-best-practices-for-k8s/certsuite/pull/3494)
- [certsuite-operator#286](https://github.com/redhat-best-practices-for-k8s/certsuite-operator/pull/286)
- [certsuite-claim#164](https://github.com/redhat-best-practices-for-k8s/certsuite-claim/pull/164)
- [kpi-collection-tool#68](https://github.com/redhat-best-practices-for-k8s/kpi-collection-tool/pull/68)
- [perfdive#51](https://github.com/redhat-best-practices-for-k8s/perfdive/pull/51)
- [cr-scale-operator#6](https://github.com/redhat-best-practices-for-k8s/cr-scale-operator/pull/6)
- [certsuite-qe#1379](https://github.com/redhat-best-practices-for-k8s/certsuite-qe/pull/1379)
- [certsuite-overview#122](https://github.com/redhat-best-practices-for-k8s/certsuite-overview/pull/122)
- [privileged-daemonset#341](https://github.com/redhat-best-practices-for-k8s/privileged-daemonset/pull/341)
- [billerica-lab#1](https://github.com/redhat-best-practices-for-k8s/billerica-lab/pull/1)
- [json-parser#2](https://github.com/redhat-best-practices-for-k8s/json-parser/pull/2)
- [kpi-analyzer#10](https://github.com/redhat-best-practices-for-k8s/kpi-analyzer/pull/10)
- [collector#661](https://github.com/redhat-best-practices-for-k8s/collector/pull/661)
- [operator-results-spreadsheet#43](https://github.com/redhat-best-practices-for-k8s/operator-results-spreadsheet/pull/43)
- [team-highlights#3](https://github.com/redhat-best-practices-for-k8s/team-highlights/pull/3)
- [operators-CNF-cert-results#4](https://github.com/redhat-best-practices-for-k8s/operators-CNF-cert-results/pull/4)
- [oct#414](https://github.com/redhat-best-practices-for-k8s/oct/pull/414)
- [vz-cnf-best-practices-guide#20](https://github.com/redhat-best-practices-for-k8s/vz-cnf-best-practices-guide/pull/20)
- [collector-aws#5](https://github.com/redhat-best-practices-for-k8s/collector-aws/pull/5)
- [openshift-security-dashboard#1](https://github.com/redhat-best-practices-for-k8s/openshift-security-dashboard/pull/1)
- [certsuite-probe#68](https://github.com/redhat-best-practices-for-k8s/certsuite-probe/pull/68)
- [certsuite-operator-plugin#11](https://github.com/redhat-best-practices-for-k8s/certsuite-operator-plugin/pull/11)
- [certsuite-operator-plugin-teset#3](https://github.com/redhat-best-practices-for-k8s/certsuite-operator-plugin-teset/pull/3)
- [certsuite-sample-workload#653](https://github.com/redhat-best-practices-for-k8s/certsuite-sample-workload/pull/653)
- [guide#28](https://github.com/redhat-best-practices-for-k8s/guide/pull/28)
- [custom-catalog-builder#21](https://github.com/redhat-best-practices-for-k8s/custom-catalog-builder/pull/21)
- [telco-bot#118](https://github.com/redhat-best-practices-for-k8s/telco-bot/pull/118)
- [parser#102](https://github.com/redhat-best-practices-for-k8s/parser/pull/102)