### PR TITLE
chore: update Go to v1.26.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,7 +184,7 @@ The `MemcachedReconciler`:
 
 | Dependency | Version | Purpose |
 |------------|---------|---------|
-| Go | 1.26.0 | Programming language |
+| Go | 1.26.1 | Programming language |
 | controller-runtime | v0.14.1 | Operator framework |
 | Kubernetes client-go | v0.26.0 | Kubernetes API client |
 | Ginkgo | v2.6.0 | BDD testing framework |
@@ -196,7 +196,7 @@ The `MemcachedReconciler`:
 ## Development Guidelines
 
 ### Go Version
-This project uses Go 1.26.0. Ensure your local environment matches this version.
+This project uses Go 1.26.1. Ensure your local environment matches this version.
 
 ### Kubebuilder Scaffolding
 This project was generated using Kubebuilder v3 with the Operator SDK plugins. The project layout follows standard Kubebuilder conventions.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/test-network-function/cr-scale-operator
 
-go 1.26.0
+go 1.26.1
 
 require (
 	github.com/onsi/ginkgo/v2 v2.6.0


### PR DESCRIPTION
## Summary
- Update Go version from 1.26.0 to 1.26.1

## Jira
- [CNFCERT-1370](https://issues.redhat.com/browse/CNFCERT-1370)

## Related PRs
- [certsuite#3516](https://github.com/redhat-best-practices-for-k8s/certsuite/pull/3516)