### PR TITLE
fix: replace deprecated gcr.io registry with registry.k8s.io for kube-rbac-proxy

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -31,7 +31,7 @@ spec:
           capabilities:
             drop:
               - "ALL"
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
+        image: registry.k8s.io/kubebuilder/kube-rbac-proxy:v0.13.1
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"


### PR DESCRIPTION
## Summary

- The `gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1` image is no longer available from gcr.io (Google Container Registry has been deprecated)
- This causes `ImagePullBackOff` errors when deploying the cr-scale-operator, breaking Kind CI clusters in downstream repos
- Replace with `registry.k8s.io/kubebuilder/kube-rbac-proxy:v0.13.1` which is the official replacement registry

## Test plan

- Verified the image is pullable from registry.k8s.io
- Downstream certsuite-sample-workload CI should pass with this fix