### PR TITLE
fix: use quay.io mirror for kube-rbac-proxy image

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -31,7 +31,7 @@ spec:
           capabilities:
             drop:
               - "ALL"
-        image: registry.k8s.io/kubebuilder/kube-rbac-proxy:v0.13.1
+        image: quay.io/redhat-best-practices-for-k8s/kube-rbac-proxy:v0.13.1
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"


### PR DESCRIPTION
## Summary

- Mirror the kube-rbac-proxy:v0.13.1 image to quay.io/redhat-best-practices-for-k8s/kube-rbac-proxy:v0.13.1
- This replaces registry.k8s.io (from PR #8) with our own org mirror for full control over image availability
- Avoids dependency on external registries (gcr.io deprecated, registry.k8s.io may rate-limit)

## Test plan

- Image verified as pushed and pullable from quay.io