### PR TITLE
chore: upgrade to Go 1.26.2 with toolchain directive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/test-network-function/cr-scale-operator
 
-go 1.26.1
+go 1.26
+
+toolchain go1.26.2
 
 require (
 	github.com/onsi/ginkgo/v2 v2.6.0


### PR DESCRIPTION
## Summary

Set `go 1.26` as the minimum language version with `toolchain go1.26.2` in go.mod for improved compatibility and security.

## Security Fixes

[Go 1.26.2 announcement](https://groups.google.com/g/golang-announce/c/EdhZqrQ98hk/m/41DopX_WAAAJ) — 10 CVEs fixed:

| CVE | Package | Issue |
|-----|---------|-------|
| CVE-2026-27140 | cmd/go | Code smuggling via crafted SWIG file names |
| CVE-2026-27143 | cmd/compile | Invalid arithmetic over loop induction variables |
| CVE-2026-27144 | cmd/compile | Incorrect pointer unwrapping in memory moves |
| CVE-2026-32280 | crypto/x509 | DoS via unlimited chain building with many intermediates |
| CVE-2026-32281 | crypto/x509 | DoS via inefficient policy mapping validation |
| CVE-2026-32282 | os (unix) | Symlink traversal in Root.Chmod on Linux |
| CVE-2026-32283 | crypto/tls | TLS 1.3 deadlock from multiple key update messages |
| CVE-2026-32288 | archive/tar | Unbounded memory allocation from sparse map entries |
| CVE-2026-32289 | html/template | XSS via incorrect escaping in JS template literals |
| CVE-2026-33810 | crypto/x509 | DNS constraint bypass with case-sensitive wildcards |

## Related PRs

- redhat-best-practices-for-k8s/certsuite#3555
- redhat-best-practices-for-k8s/certsuite-claim#166
- redhat-best-practices-for-k8s/certsuite-operator#298
- redhat-best-practices-for-k8s/certsuite-overview#133
- redhat-best-practices-for-k8s/certsuite-qe#1433
- redhat-best-practices-for-k8s/checks#31
- redhat-best-practices-for-k8s/collector#675
- redhat-best-practices-for-k8s/kpi-collection-tool#87
- redhat-best-practices-for-k8s/oct#426
- redhat-best-practices-for-k8s/perfdive#58
- redhat-best-practices-for-k8s/privileged-daemonset#350